### PR TITLE
Adding I2C option to .begin()

### DIFF
--- a/MLX90393.h
+++ b/MLX90393.h
@@ -48,7 +48,8 @@ public:
   uint8_t nop();
 
   // higher-level API
-  uint8_t begin(uint8_t A1 = 0, uint8_t A0 = 0, int DRDY_pin = -1);
+  uint8_t begin(uint8_t A1 = 0, uint8_t A0 = 0, int DRDY_pin = -1, TwoWire &wirePort = Wire);
+
   uint8_t readData(txyz& data);
   uint8_t setGainSel(uint8_t gain_sel);
   uint8_t getGainSel(uint8_t& gain_sel);
@@ -121,5 +122,9 @@ private:
   void invalidateCache();
   uint8_t checkStatus(uint8_t status);
   txyz convertRaw(txyzRaw raw);
+  
+  private:
+    TwoWire *_i2cPort; //The generic connection to user's chosen I2C hardware
+
 };
 #endif // #ifndef MLX90393_H_INCLUDED


### PR DESCRIPTION
User can pass Wire or Wire1, etc to .begin to get access to other I2C streams.